### PR TITLE
adjust upper, lower, middle to handle NAs

### DIFF
--- a/R/distribution_parts.R
+++ b/R/distribution_parts.R
@@ -29,14 +29,16 @@ middle <- function(x, prop = .95, greedy = TRUE) {
   tail_prop <- (1 - prop) / 2
   in_upper <- upper(x, tail_prop, !greedy)
   in_lower <- lower(x, tail_prop, !greedy)
-  !in_upper & !in_lower
+  is_NA <- is.na(x)
+  
+  !in_upper & !in_lower & !is_NA
 }
 
 
 #' @rdname distribution_parts
 #' @export
 lower <- function(x, prop = .025, greedy = TRUE) {
-  tail_size <- if (greedy) ceiling(length(x) * prop) else floor(length(x) * prop)
+  tail_size <- if (greedy) ceiling(length(na.omit(x)) * prop) else floor(length(na.omit(x)) * prop)
 
   values <- data.frame(x = x, original_pos = seq_along(x))
   values <- values[order(x), , drop = FALSE]
@@ -49,7 +51,7 @@ lower <- function(x, prop = .025, greedy = TRUE) {
 #' @rdname distribution_parts
 #' @export
 upper <- function(x, prop = .025, greedy = TRUE) {
-  tail_size <- if (greedy) ceiling(length(x) * prop) else floor(length(x) * prop)
+  tail_size <- if (greedy) ceiling(length(na.omit(x)) * prop) else floor(length(na.omit(x)) * prop)
 
   values <- data.frame(x = x, original_pos = seq_along(x))
   values <- values[order(x, decreasing = TRUE), , drop = FALSE]

--- a/man/distribution_parts.Rd
+++ b/man/distribution_parts.Rd
@@ -29,6 +29,9 @@ is a greedy operation, meaning that if the cutoff point is between two whole num
 specified region will suck up the extra space. For example, the requesting the upper 30\% of the
 \code{[1 2 3 4]} will return \code{[FALSE FALSE TRUE TRUE]} because the 30\% was greedy.
 }
+\details{
+Note that \code{NA} values are ignored, i.e. they will always return \code{FALSE}.
+}
 \examples{
 
 upper(1:10, .1)

--- a/tests/testthat/test-distribution_parts.R
+++ b/tests/testthat/test-distribution_parts.R
@@ -35,3 +35,9 @@ test_that("the values do not need to be pre-arranged", {
   expect_identical(upper(c(2, 1, 3, 4), .25), c(FALSE, FALSE, FALSE, TRUE))
   expect_identical(middle(c(2, 1, 3, 4), .5), c(TRUE, FALSE, TRUE, FALSE))
 })
+
+test_that("it ignores NA values", {
+  expect_identical(lower(c(2, 1, 3, 4, NA_real_), .25), c(FALSE, TRUE, FALSE, FALSE, FALSE))
+  expect_identical(upper(c(2, 1, 3, 4, NA_real_), .25), c(FALSE, FALSE, FALSE, TRUE, FALSE))
+  expect_identical(middle(c(2, 1, 3, 4, NA_real_), .5), c(TRUE, FALSE, TRUE, FALSE, FALSE))
+})


### PR DESCRIPTION
To upper and lower, adjust the calculation of length to ignore NA. Not sure if we want to do this but all functions returns FALSE for NA values (e.g., NA is not in upper nor lower).

Adjust middle to be like upper and lower (return FALSE for NA; before middle returned TRUE for NA)

